### PR TITLE
Fix the __ok() function to work for boolean

### DIFF
--- a/jinja_to_js/js_functions.py
+++ b/jinja_to_js/js_functions.py
@@ -4,16 +4,16 @@ function __ok(o) {
     if (!o) {
         return false;
     }
+    if (o === true) {
+        return o;
+    }
     if (Array.isArray(o)) {
         return o.length > 0;
     }
-    try {
-        var keys = Object.keys(o);
+    if (__type(o) === 'Object') {
+        return Object.keys(o).length > 0;
     }
-    catch (e) {
-        return !!o;
-    }
-    return keys.length > 0;
+    return !!o;
 }
 """
 

--- a/tests/templates/truthy_falsey_values.jinja
+++ b/tests/templates/truthy_falsey_values.jinja
@@ -35,3 +35,11 @@
 {% if empty_string %}
     string is empty
 {% endif %}
+
+{% if boolean_true %}
+    boolean value is true
+{% endif %}
+
+{% if not boolean_false %}
+    boolean value is false
+{% endif %}

--- a/tests/test_jinja_to_js.py
+++ b/tests/test_jinja_to_js.py
@@ -245,7 +245,9 @@ class Tests(unittest.TestCase):
                        empty_object={},
                        non_empty_object=dict(inner_key='one', inner_obj=dict(inner_inner_key=5)),
                        empty_string='',
-                       non_empty_string='hello')
+                       non_empty_string='hello',
+                       boolean_true=True,
+                       boolean_false=False)
 
     def test_comparisons(self):
         self._run_test('comparisons.jinja',


### PR DESCRIPTION
Node.js and Chrome treat Object.keys(true) differently. In Node.js
it throws an error but in Chrome (and other browsers) you get an
empty array. This was causing __ok(true) to return false :(