### PR TITLE
Add support for specifying custom filters

### DIFF
--- a/jinja_to_js/__main__.py
+++ b/jinja_to_js/__main__.py
@@ -68,6 +68,13 @@ def get_arg_parser():
         dest="include_ext"
     )
 
+    parser.add_argument(
+        "-f", "--filters", nargs='*',
+        help="Specifies custom filters to be allowed.",
+        default='',
+        dest="custom_filters"
+    )
+
     return parser
 
 

--- a/tests/render_template.js
+++ b/tests/render_template.js
@@ -18,6 +18,13 @@ for (var key in data) {
     }
 }
 
+// add custom filter
+require('../jinja-to-js-runtime.js').filters.unicode_snowmen = function (value) {
+    return value.split('').map(function () {
+        return '☃';
+    }).join('');
+};
+
 process.stdout.write(require(args[2])(data));
 
 function readFile(name) {

--- a/tests/templates/custom_filters.jinja
+++ b/tests/templates/custom_filters.jinja
@@ -1,0 +1,1 @@
+{{ '!!!'|unicode_snowmen }}

--- a/tests/test_jinja_to_js.py
+++ b/tests/test_jinja_to_js.py
@@ -320,6 +320,14 @@ class Tests(unittest.TestCase):
                                    'includes/quiet_name.jinja',
                                    'includes/nested/loud_name.jinja'],)
 
+    def test_custom_filters(self):
+        def unicode_snowmen(value):
+            return ''.join(['☃' for x in value])
+
+        self.env.filters['unicode_snowmen'] = unicode_snowmen
+
+        self._run_test('custom_filters.jinja')
+
     def _run_test(self, name, additional=None, **kwargs):
 
         # first we'll render the jinja template
@@ -362,7 +370,8 @@ class Tests(unittest.TestCase):
             template_root=self.TEMPLATE_PATH,
             template_name=name,
             js_module_format='commonjs',
-            runtime_path=abspath('jinja-to-js-runtime.js')
+            runtime_path=abspath('jinja-to-js-runtime.js'),
+            custom_filters=['unicode_snowmen']
         ).get_output()
 
         target = self.temp_dir + '/' + os.path.splitext(name)[0] + '.js'


### PR DESCRIPTION
@iprignano @djmc @skyllo

This allow you specify some custom filters that jinja-to-js should assume you have implemented in both your Jinja and JS environments. See the unit test for an example.