### PR TITLE
Add support for custom filters in extended templates

### DIFF
--- a/jinja_to_js/__init__.py
+++ b/jinja_to_js/__init__.py
@@ -334,7 +334,8 @@ class JinjaToJS(object):
                                     include_prefix=self.include_prefix,
                                     include_ext=self.include_ext,
                                     child_blocks=self.child_blocks,
-                                    dependencies=self.dependencies)
+                                    dependencies=self.dependencies,
+                                    custom_filters=self.custom_filters)
 
         # add the parent templates output to the current output
         self.output.write(parent_template.output.getvalue())

--- a/tests/templates/custom_filters_and_extends.jinja
+++ b/tests/templates/custom_filters_and_extends.jinja
@@ -1,0 +1,1 @@
+{% extends 'custom_filters.jinja' %}

--- a/tests/test_jinja_to_js.py
+++ b/tests/test_jinja_to_js.py
@@ -327,6 +327,7 @@ class Tests(unittest.TestCase):
         self.env.filters['unicode_snowmen'] = unicode_snowmen
 
         self._run_test('custom_filters.jinja')
+        self._run_test('custom_filters_and_extends.jinja')
 
     def _run_test(self, name, additional=None, **kwargs):
 


### PR DESCRIPTION
Was running into `Exception: Unsupported filter:` when trying to use custom filters with `extends`. Think I found the bug.

Also, thanks for writing this tool -- super handy.