### PR TITLE
Jinja2 version >= 9 seems to have broken {% with %}

### DIFF
--- a/jinja_to_js/__init__.py
+++ b/jinja_to_js/__init__.py
@@ -788,6 +788,12 @@ class JinjaToJS(object):
             self._process_node(node.node, **kwargs)
             self.output.write(';')
 
+    def _process_with(self, node, **kwargs):
+        """
+        New node name Jinja2 >= 2.9
+        """
+        self._process_scope(node, **kwargs)
+
     def _process_scope(self, node, **kwargs):
 
         # keep a copy of the stored names before the scope


### PR DESCRIPTION
This fix might be a hack but it seems to have fixed my problem. My assessment is that at some point Jinja2 switched the node name from scope --> with.  