### PR TITLE
Don't add duplicate dependencies

### DIFF
--- a/jinja_to_js/__init__.py
+++ b/jinja_to_js/__init__.py
@@ -296,7 +296,9 @@ class JinjaToJS(object):
         """
         if var_name is None:
             var_name = next(self.temp_var_names)
-        self.dependencies.append((dependency, var_name))
+        # Don't add duplicate dependencies
+        if (dependency, var_name) not in self.dependencies:
+            self.dependencies.append((dependency, var_name))
         return var_name
 
     def _process_node(self, node, **kwargs):

--- a/tests/test_jinja_to_js.py
+++ b/tests/test_jinja_to_js.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, unicode_literals, print_function
 import json
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -340,6 +341,15 @@ class Tests(unittest.TestCase):
         self.env.globals['convert_to_uppercase'] = convert_to_uppercase
 
         self._run_test('custom_global.jinja')
+
+    def test_extends_es6(self):
+        compiler = JinjaToJS(template_root=self.TEMPLATE_PATH,
+                             template_name='extends.jinja',
+                             js_module_format='es6'
+                    )
+        output = compiler.get_output()
+        import_count = len(re.findall('import', output))
+        assert import_count == 1
 
     def _run_test(self, name, additional=None, **kwargs):
 


### PR DESCRIPTION
## The bug
When compiling a template using  an es6 module from a template that uses the `{% extends ...%}` operator multiple `import jinjaToJS from "jinja-to-js"` were added to the output. 

This is not valid es6 syntax. 

### Example before this fix
```bash
$ jinja_to_js /Users/matthewlawson/Code/Packages/jinja-to-js/tests/templates extends.jinja --js-module-format=es6
```
```javascript
import jinjaToJS from "jinja-to-js";import jinjaToJS from "jinja-to-js";import jinjaToJS from "jinja-to-js";export default function templateExtends(ctx) {
    var __result = "";
    var __tmp;
    var __runtime = jinjaToJS.runtime;
    var __filters = jinjaToJS.filters;
    var __globals = jinjaToJS.globals;
    var context = jinjaToJS.createContext(ctx);
    __result += "I am part of the grandparent\n\n";__result += "\n    one grandparent\n";__result += "\n\n";__result += "\n    two parent\n";__result += "\n\n";__result += "\n    three parent\n    ";__result += "\n    three grandparent\n";__result += "\n";__result += "\n\n";__result += "\n    four child\n    ";__result += "\n    four parent\n    ";__result += "\n    four grandparent\n";__result += "\n";__result += "\n";__result += "\n\nI am also part of the grandparent";
    return __result;
}%
```
### Example after this fix
```bash
$~/PythonEnvironments/jinja-to-js/bin/jinja_to_js /Users/matthewlawson/Code/Packages/jinja-to-js/tests/templates extends.jinja --js-module-format=es6
```
```javascript
import jinjaToJS from "jinja-to-js";export default function templateExtends(ctx) {
    var __result = "";
    var __tmp;
    var __runtime = jinjaToJS.runtime;
    var __filters = jinjaToJS.filters;
    var __globals = jinjaToJS.globals;
    var context = jinjaToJS.createContext(ctx);
    __result += "I am part of the grandparent\n\n";__result += "\n    one grandparent\n";__result += "\n\n";__result += "\n    two parent\n";__result += "\n\n";__result += "\n    three parent\n    ";__result += "\n    three grandparent\n";__result += "\n";__result += "\n\n";__result += "\n    four child\n    ";__result += "\n    four parent\n    ";__result += "\n    four grandparent\n";__result += "\n";__result += "\n";__result += "\n\nI am also part of the grandparent";
    return __result;
}%
```