### PR TITLE
Add support for Windows

### DIFF
--- a/jinja_to_js/__init__.py
+++ b/jinja_to_js/__init__.py
@@ -227,6 +227,10 @@ class JinjaToJS(object):
 
         self._add_dependency(self.runtime_path, 'jinjaToJS')
 
+        # Jinja2 doesn't accept Windows filepaths
+        if os.name == 'nt':
+            self.template_name = self.template_name.replace(os.pathsep, '/')
+
         template_string, template_path, _ = self.environment.loader.get_source(
             self.environment, self.template_name
         )
@@ -971,6 +975,10 @@ class JinjaToJS(object):
                     )
                     if not include_path.startswith('.'):
                         include_path = './' + include_path
+
+                # Jinja2 doesn't accept Windows filepaths (but does output them!)
+                if os.name == 'nt':
+                    include_path = include_path.replace(os.pathsep, '/')
 
                 include_path = path.splitext(include_path)[0] + self.include_ext
                 include_var_name = self._get_depencency_var_name(include_path)


### PR DESCRIPTION
This solves two problems:
- Jinja2 crashes if you pass the FileSystemLoader a windows path
- The FileSystemLoader returns Windows paths for dependencies, which turn
  into escape sequences when rendered in JS.