### PR TITLE
Fix Custom Filters and Tests on Windows

### DIFF
--- a/jinja_to_js/__init__.py
+++ b/jinja_to_js/__init__.py
@@ -158,6 +158,13 @@ def temp_var_names_generator():
         x += 1
 
 
+def clean_path(file_path):
+    # Jinja2 doesn't accept Windows filepaths (but does output them!)
+    if os.name == 'nt':
+        return file_path.replace(os.path.sep, '/')
+    return file_path
+
+
 class JinjaToJS(object):
 
     def __init__(self,
@@ -227,9 +234,7 @@ class JinjaToJS(object):
 
         self._add_dependency(self.runtime_path, 'jinjaToJS')
 
-        # Jinja2 doesn't accept Windows filepaths
-        if os.name == 'nt':
-            self.template_name = self.template_name.replace(os.pathsep, '/')
+        self.template_name = clean_path(self.template_name)
 
         template_string, template_path, _ = self.environment.loader.get_source(
             self.environment, self.template_name
@@ -298,6 +303,7 @@ class JinjaToJS(object):
         Returns:
             str
         """
+        dependency = clean_path(dependency)
         if var_name is None:
             var_name = next(self.temp_var_names)
         # Don't add duplicate dependencies
@@ -977,9 +983,7 @@ class JinjaToJS(object):
                     if not include_path.startswith('.'):
                         include_path = './' + include_path
 
-                # Jinja2 doesn't accept Windows filepaths (but does output them!)
-                if os.name == 'nt':
-                    include_path = include_path.replace(os.pathsep, '/')
+                include_path = clean_path(include_path)
 
                 include_path = path.splitext(include_path)[0] + self.include_ext
                 include_var_name = self._get_depencency_var_name(include_path)

--- a/jinja_to_js/__init__.py
+++ b/jinja_to_js/__init__.py
@@ -342,7 +342,8 @@ class JinjaToJS(object):
                                     include_prefix=self.include_prefix,
                                     include_ext=self.include_ext,
                                     child_blocks=self.child_blocks,
-                                    dependencies=self.dependencies)
+                                    dependencies=self.dependencies,
+                                    custom_filters=self.custom_filters)
 
         # add the parent templates output to the current output
         self.output.write(parent_template.output.getvalue())

--- a/tests/templates/extends_custom_filters.jinja
+++ b/tests/templates/extends_custom_filters.jinja
@@ -1,0 +1,1 @@
+{% extends 'custom_filters.jinja' %}

--- a/tests/test_jinja_to_js.py
+++ b/tests/test_jinja_to_js.py
@@ -397,7 +397,7 @@ class Tests(unittest.TestCase):
             template_root=self.TEMPLATE_PATH,
             template_name=name,
             js_module_format='commonjs',
-            runtime_path=abspath('../jinja-to-js-runtime.js'),
+            runtime_path=abspath('jinja-to-js-runtime.js'),
             custom_filters=['unicode_snowmen']
         ).get_output()
 

--- a/tests/test_jinja_to_js.py
+++ b/tests/test_jinja_to_js.py
@@ -18,7 +18,7 @@ from jinja2.loaders import FileSystemLoader
 
 import pytest
 
-from jinja_to_js import JinjaToJS, is_method_call
+from jinja_to_js import JinjaToJS, is_method_call, clean_path
 
 if "check_output" not in dir(subprocess):
     def check_output(*popenargs, **kwargs):
@@ -357,11 +357,11 @@ class Tests(unittest.TestCase):
         jinja_result = self.env.get_template(name).render(**kwargs).strip()
 
         # create the main template
-        path = self._compile_js_template(name)
+        path = clean_path(self._compile_js_template(name))
         template_args = [path]
 
         # create a temp file containing the data
-        data_file_path = self._write_to_temp_file(json.dumps(kwargs, cls=Encoder))
+        data_file_path = clean_path(self._write_to_temp_file(json.dumps(kwargs, cls=Encoder)))
 
         # if additional template are required e.g. for includes then create those too
         if additional:
@@ -372,7 +372,7 @@ class Tests(unittest.TestCase):
         try:
             js_result = check_output(
                 ['node',
-                 self.NODE_SCRIPT_PATH]
+                 clean_path(self.NODE_SCRIPT_PATH)]
                 + template_args +
                 [data_file_path]
             )
@@ -397,11 +397,11 @@ class Tests(unittest.TestCase):
             template_root=self.TEMPLATE_PATH,
             template_name=name,
             js_module_format='commonjs',
-            runtime_path=abspath('jinja-to-js-runtime.js'),
+            runtime_path=abspath('../jinja-to-js-runtime.js'),
             custom_filters=['unicode_snowmen']
         ).get_output()
 
-        target = self.temp_dir + '/' + os.path.splitext(name)[0] + '.js'
+        target = os.path.join(self.temp_dir, os.path.splitext(name)[0] + '.js')
 
         if not os.path.exists(os.path.dirname(target)):
             os.makedirs(os.path.dirname(target))

--- a/tests/test_jinja_to_js.py
+++ b/tests/test_jinja_to_js.py
@@ -334,6 +334,14 @@ class Tests(unittest.TestCase):
 
         self._run_test('custom_filters.jinja')
 
+    def test_extends_custom_filters(self):
+        def unicode_snowmen(value):
+            return ''.join(['☃' for x in value])
+
+        self.env.filters['unicode_snowmen'] = unicode_snowmen
+
+        self._run_test('extends_custom_filters.jinja')
+
     def test_custom_global(self):
         def convert_to_uppercase(value):
             return value.upper()


### PR DESCRIPTION
Correctly pass custom_filters to inherited templates.

Fix path \ to / conversion on windows.

Fix test running on windows.